### PR TITLE
Extend README selinux proposed to cover init based services

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,11 +91,13 @@ a file collectd_systemd.te::
     policy_module(collectd_systemd,0.1);
     require {
         type collectd_t;
+        type initrc_exec_t;
     }
     dbus_session_client(system,collectd_t)
     init_status(collectd_t)
     init_dbus_chat(collectd_t)
     systemd_status_all_unit_files(collectd_t)
+    allow collectd_t initrc_exec_t:service { status };
 
 Create a file collectd_systemd.pp and install it::
 


### PR DESCRIPTION
The latest Fedora RPMs fixes the issue reported about probing initd based services.

This PR extends the proposed SELinux in the README file for people not using RPM to be aware of the issue.

It closes https://github.com/mbachry/collectd-systemd/issues/5