### PR TITLE
Consider a dead oneshot service good

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,13 @@ collectd-systemd
     :alt: Coverage
     :target: https://coveralls.io/github/mbachry/collectd-systemd?branch=master
 
-A `collectd`_ plugin which checks if given `systemd`_ services are in
-"running" state and sends `graphite`_ metrics with ``1.0`` or ``0.0``
-value.
+A `collectd`_ plugin which checks if given `systemd`_ services are one of
+* state "running"
+* state "reloading"
+* state "dead" with a service type is "oneshot"
+in each of these cases it sends sends `graphite`_ metrics of ``1.0``.
+Otherwise it will send a ``0.0`` value.
+
 
 The plugin is particularly useful together with `grafana's alerting`_.
 


### PR DESCRIPTION
For a oneshot service, particular those started by a timer,
it is perfectly normal for a status
to be `dead`. e.g.

```
systemctl status mlocate-updatedb.service
● mlocate-updatedb.service - Update a database for mlocate
   Loaded: loaded (/usr/lib/systemd/system/mlocate-updatedb.service; static; vendor preset: disabled)
   Active: inactive (dead) since Mon 2020-06-15 00:00:10 CEST; 3 days ago
 Main PID: 28558 (code=exited, status=0/SUCCESS)
```

This patch checks the service type and considers a dead oneshot service
as a good service.

For completness when a oneshot command fails for whatever reason it appears as

```
● mlocate-updatedb.service - Update a database for mlocate
   Loaded: loaded (/usr/lib/systemd/system/mlocate-updatedb.service; static; vendor preset: disabled)
   Active: failed (Result: exit-code) since Thu 2020-06-18 18:58:29 CEST; 6s ago
  Process: 70720 ExecStart=/usr/libexec/mlocate-run-updated (code=exited, status=203/EXEC)
 Main PID: 70720 (code=exited, status=203/EXEC)
```

and this `failed` reports as an error status to collectd.