### PR TITLE
Consider state start as a good state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ collectd-systemd
     :target: https://coveralls.io/github/mbachry/collectd-systemd?branch=master
 
 A `collectd`_ plugin which checks if given `systemd`_ services are in
-"running" state and sends `graphite`_ metrics with ``1.0`` or ``0.0``
+"running", "start" or "reload", state and sends `graphite`_ metrics with ``1.0`` or ``0.0``
 value.
 
 The plugin is particularly useful together with `grafana's alerting`_.

--- a/collectd_systemd.py
+++ b/collectd_systemd.py
@@ -77,7 +77,7 @@ class SystemD(object):
                 self.init_dbus()
                 state = self.get_service_state(full_name)
 
-            value = (1.0 if state == 'running' or state == 'reload' else 0.0)
+            value = (1.0 if state == 'running' or state == 'reload' or state == 'start' else 0.0)
             self.log_verbose('Sending value: {}.{}={} (state={})'
                              .format(self.plugin_name, name, value, state))
             val = collectd.Values(


### PR DESCRIPTION
A service that is being started is a good state and should
be considered so by this sensor.

A service will stay in start state until TimeoutStartSec= is
reached. Default for this timeout is 90 seconds but infinity
for a oneshot service which will remain in start
state forever by default.

Worth noting that  one-shot services that are hanging forever will not be identified unless
a timeout is specified in the unit but I think that is fine.