### PR TITLE
Use LoadUnit rather than GetUnit for stable names

### DIFF
--- a/collectd_systemd.py
+++ b/collectd_systemd.py
@@ -26,7 +26,7 @@ class SystemD(object):
         if name not in self.units:
             try:
                 unit = dbus.Interface(self.bus.get_object('org.freedesktop.systemd1',
-                                                          self.manager.GetUnit(name)),
+                                                          self.manager.LoadUnit(name)),
                                       'org.freedesktop.DBus.Properties')
             except dbus.exceptions.DBusException as e:
                 collectd.warning('{} plugin: failed to monitor unit {}: {}'.format(


### PR DESCRIPTION
Particularly with onetime units they can be unloaded and not longer appear.

Using LoadUnit instead seems to be much more reliable.

https://github.com/systemd/systemd/issues/1929#issuecomment-160288019

contains a justification.